### PR TITLE
Don't bake config.json into Docker image, add JSON schema

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,3 +33,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+chip-in-calculator
+config.schema.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ WORKDIR /
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/chip-in-calculator /chip-in-calculator
-COPY --from=builder /build/config.json /config.json
 
 ENTRYPOINT ["/chip-in-calculator"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Chip-in Calculator
 
-## How to run
-
-### Flags
+## Flags
 
 | Flag             | Required | Default       | Description                                 |
 | ---------------- | -------- | ------------- | ------------------------------------------- |
@@ -10,62 +8,45 @@
 | `-c`, `--config` | No       | `config.json` | Path to config file                         |
 | `--mentions`     | No       | —             | Mentions to put into message after greeting |
 
-### Build docker image
+## Config
 
-```bash
-docker build -t chip-in-calculator . \
-&& docker run --rm chip-in-calculator -r 45.33
+See [`config.schema.json`](config.schema.json) for the full schema. Example:
 
-docker build -t chip-in-calculator . \
-&& docker run --rm chip-in-calculator --rate 47.11
-
-# With custom config file
-docker build -t chip-in-calculator . \
-&& docker run --rm -v $(pwd)/config2.json:/config2.json \
-chip-in-calculator -r 45.33 -c config2.json
+```json
+{
+  "subscriptions": [
+    { "name": "Spotify", "price": 21.99, "membersCount": 5 },
+    { "name": "Netflix", "price": 21.99, "membersCount": 3 }
+  ]
+}
 ```
 
-#### Send message to Telegram
+## Docker
+
+The image does not include a config file. Mount your own `config.json` at `/config.json`.
 
 ```bash
-docker build -t chip-in-calculator . \
-&& docker run --rm \
--e TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
--e TELEGRAM_CHAT_ID=123456 \
-chip-in-calculator --rate 45.33
+docker run --rm \
+  -v $(pwd)/config.json:/config.json \
+  -e TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
+  -e TELEGRAM_CHAT_ID=123456 \
+  ghcr.io/alexsoft/chip-in-calculator --rate 45.33
 
 # With mentions
-docker build -t chip-in-calculator . \
-&& docker run --rm \
--e TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
--e TELEGRAM_CHAT_ID=123456 \
-chip-in-calculator --rate 45.33 --mentions "@user1 @user2"
+docker run --rm \
+  -v $(pwd)/config.json:/config.json \
+  -e TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
+  -e TELEGRAM_CHAT_ID=123456 \
+  ghcr.io/alexsoft/chip-in-calculator --rate 45.33 --mentions "@user1 @user2"
 ```
 
-### Build locally, Go 1.25+
+## Build locally, Go 1.26+
 
 ```bash
-go build ./ \
-&& ./chip-in-calculator -r 45.33
+go build ./ && ./chip-in-calculator --rate 45.33
 
-go build ./ \
-&& ./chip-in-calculator --rate 47.11
-
-# With custom config file
-go build ./ \
-&& ./chip-in-calculator -r 45.33 -c config2.json
-```
-
-#### Send message to Telegram
-```bash
-go build ./ \
-&& TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
+# With Telegram
+TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
 TELEGRAM_CHAT_ID=123456 \
-./chip-in-calculator --rate 47.11
-
-# With mentions
-go build ./ \
-&& TELEGRAM_BOT_API_KEY=1111111111:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA \
-TELEGRAM_CHAT_ID=123456 \
-./chip-in-calculator --rate 47.11 --mentions "@user1 @user2"
+./chip-in-calculator --rate 45.33
 ```

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Chip-in Calculator Config",
+  "type": "object",
+  "required": ["subscriptions"],
+  "additionalProperties": false,
+  "properties": {
+    "subscriptions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "price", "membersCount"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "price": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "membersCount": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/alexsoft/chip-in-calculator/calculator"
@@ -31,7 +33,12 @@ func main() {
 
 	cfg, err := config.Load(opts.ConfigPath)
 	if err != nil {
-		fmt.Println("Error loading config:", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			fmt.Printf("Config file not found: %s\n", opts.ConfigPath)
+			fmt.Println("Mount your config file: docker run -v $(pwd)/config.json:/config.json ...")
+		} else {
+			fmt.Println("Error loading config:", err)
+		}
 		os.Exit(1)
 	}
 

--- a/notifier/telegram.go
+++ b/notifier/telegram.go
@@ -23,7 +23,6 @@ func (s *TelegramSender) Send(message string) error {
 		return errors.New("missing Telegram chat ID")
 	}
 
-	// Implementation for sending message via Telegram API
 	fmt.Println("Sending message via Telegram:", message)
 
 	body, err := json.Marshal(map[string]any{


### PR DESCRIPTION
Users must now mount their own config.json at runtime. Adds a config.schema.json for validation and a clearer error message when the config file is missing.